### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 transformers==4.4.2
 pytorch==1.7.0
-sklearn
+scikit-learn
 tqdm
 numpy
 scipy==1.2.1


### PR DESCRIPTION
use pip install scikit-learn rather than pip install sklearn

https://pypi.org/project/sklearn/ : 

This repo implements the brownout strategy for deprecating the sklearn package on PyPI.

How to fix the error for the main use cases
use pip install scikit-learn rather than pip install sklearn
replace sklearn by scikit-learn in your pip requirements files (requirements.txt, setup.py, setup.cfg, Pipfile, etc ...)
if the sklearn package is used by one of your dependencies it would be great if you take some time to track which package uses sklearn instead of scikit-learn and report it to their issue tracker
as a last resort, set the environment variable SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True to avoid this error